### PR TITLE
Update Würzburg parser

### DIFF
--- a/wuerzburg/__init__.py
+++ b/wuerzburg/__init__.py
@@ -42,7 +42,7 @@ class Parser:
                 try:
                     name = meal.find('h5').text
                     try:
-                        category = meal.find('span', class_='food-icon')['title'] 
+                        category = meal.find('span', class_='food-icon')['title']
                     except BaseException:
                         logging.warning("Meal type of %s (%s) is unknown", name, date)
                         category = "unknown"

--- a/wuerzburg/canteenDict.json
+++ b/wuerzburg/canteenDict.json
@@ -1,9 +1,58 @@
 {
+  "mensa-hochschulcampus-aschaffenburg": {
+    "name": "Aschaffenburg, Mensa Hochschulcampus 🆕",
+    "city": "Aschaffenburg",
+    "address": "Würzburger-Straße 45, 63743 Aschaffenburg",
+    "latitude": 49.971510,
+    "longitude": 9.160257
+  },
+  "mensa-austrasse-bamberg": {
+    "name": "Bamberg, Mensa Austraße 🆕",
+    "city": "Bamberg",
+    "address": "Austraße 37, 96047 Bamberg",
+    "latitude": 49.893556,
+    "longitude": 10.886982
+  },
+  "mensa-feldkirchenstrasse-bamberg": {
+    "name": "Bamberg, Mensa Feldkirchenstraße 🆕",
+    "city": "Bamberg",
+    "address": "Feldkirchenstraße 21, 96052 Bamberg",
+    "latitude": 49.906709,
+    "longitude": 10.905138
+  },
+  "mensa-thws-campus-schweinfurt": {
+    "name": "Schweinfurt, Mensa THWS Campus 🆕",
+    "city": "Schweinfurt",
+    "address": "Fritz-Drescher-Straße 1, 97421 Schweinfurt",
+    "latitude": 50.045300,
+    "longitude": 10.208876
+  },
   "mensa-am-studentenhaus-wuerzburg": {
     "name": "Würzburg, Mensa am Studentenhaus 🆕",
     "city": "Würzburg",
     "address": "Am Studentenhaus, 97072 Würzburg",
     "latitude": 49.785892,
     "longitude": 9.934433
+  },
+  "mensateria-campus-hubland-nord-wuerzburg": {
+      "name": "Würzburg, Mensateria Campus Hubland Nord 🆕",
+      "city": "Würzburg",
+      "address": "Emil Hilb Weg 12, 97074 Würzburg",
+      "latitude": 49.785464,
+      "longitude": 9.969137
+  },
+  "mensa-josef-schneider-strasse-wuerzburg": {
+      "name": "Würzburg, Mensa Josef-Schneider-Straße 🆕",
+      "city": "Würzburg",
+      "address": "Josef-Schneider-Straße 9, 97080 Würzburg",
+      "latitude": 49.802221,
+      "longitude": 9.954735
+  },
+  "mensa-roentgenring-wuerzburg": {
+      "name": "Würzburg, Mensa Röntgenring 🆕",
+      "city": "Würzburg",
+      "address": "Röntgenring 12, 97070 Würzburg",
+      "latitude": 49.799359,
+      "longitude": 9.927276
   }
 }


### PR DESCRIPTION
Hi,
someone recently added a parser for one of the canteens operated by the Studierendenwerk Würzburg (https://github.com/cvzi/mensa/pull/61).
Since they operate a few more canteens, I added them to the canteenDict.json and changed the parsing code a bit, to always use the correct URL for the respective city.
I also added a fallback to the meal category, as the element it is derived from is sometimes not present on the website, which would lead to the meal not being parsed.

I have also never worked on openmensa. Do you know the appropriate way to remove the "old" canteens, so there are no duplicates?

Kind regards